### PR TITLE
fix: 修复 MongoDB authSource、Chromium 版本锁定、中文注释乱码及 pnpm PATH 问题

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,7 +19,7 @@ RUN echo "deb http://mirrors.aliyun.com/debian/ bookworm main non-free contrib" 
     ca-certificates libnss3 libatk-bridge2.0-0 libgtk-3-0 libx11-xcb1 \
     libxcb-dri3-0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 \
     libasound2 libxshmfence1 libdrm2 libxkbcommon0 libatspi2.0-0 libcups2 \
-    fontconfig nodejs npm fonts-wqy-zenhei fonts-wqy-microhei chromium=147.0.7727.137-1~deb12u1 chromium-common=147.0.7727.137-1~deb12u1
+    fontconfig nodejs npm fonts-wqy-zenhei fonts-wqy-microhei chromium chromium-common
 
 RUN npm config set registry https://registry.npmmirror.com/ && \
     npm install -g puppeteer-core@10.4.0

--- a/backend/config-docker.example.yaml
+++ b/backend/config-docker.example.yaml
@@ -3,7 +3,7 @@ CELERY:
 
 
 MONGO:
-  URI : 'mongodb://admin:admin@mongodb:27017/'
+  URI : 'mongodb://admin:admin@mongodb:27017/?authSource=admin'
   DB : 'arl'
 
 #GeoIP 数据库文件配置项
@@ -12,7 +12,7 @@ GEOIP:
   ASN: '/code/GeoLite2/GeoLite2-ASN.mmdb'
 
 
-#Fofa API 配置�?
+#Fofa API 配置项
 FOFA:
   URL: "https://fofa.info"
   EMAIL: "已经不需要配置了"
@@ -33,8 +33,7 @@ QUERY_PLUGIN:
     enable: true
   crtsh:
     enable: true
-  fofa:  # fofa 的key配置在上�?
-  fofa:  # fofa 的key配置在上?
+  fofa:  # fofa 的key配置在上面
     enable: true
   hunter_qax: # 网站 https://hunter.qianxin.com/
     api_key: ""
@@ -62,18 +61,18 @@ QUERY_PLUGIN:
     enable: false
 
 
-#*** 监控任务消息推送配�?****
-#监控任务消息推送配置，支持钉钉，飞书，企业微信，邮�?
-#如果不需要推送，可以将所有配置项都留�?
+#*** 监控任务消息推送配置 ****
+#监控任务消息推送配置，支持钉钉，飞书，企业微信，邮件
+#如果不需要推送，可以将所有配置项都留空
 #文档：https://tophanttechnology.github.io/ARL-doc/config_option/?h=%E6%B6%88%E6%81%AF#_1
-#钉钉消息推送配�?
-#钉钉添加机器人，请查�?
+#钉钉消息推送配置
+#钉钉添加机器人，请查看
 #https://github.com/TophantTechnology/ARL/wiki/ARL%202.3%20%E6%96%B0%E6%B7%BB%E5%8A%A0%E5%8A%9F%E8%83%BD%E8%AF%B4%E6%98%8E
 DINGDING:
   SECRET: ""
   ACCESS_TOKEN: ""
 
-#邮件推送配�?
+#邮件推送配置
 EMAIL:
   HOST: ""
   PORT: ""
@@ -81,14 +80,14 @@ EMAIL:
   PASSWORD: ""
   TO: ""
 
-#飞书消息推送配�? 需要设置签名校�?
+#飞书消息推送配置 需要设置签名校验
 #https://open.feishu.cn/document/client-docs/bot-v3/add-custom-bot
 FEISHU:
   WEBHOOK_URL: ""
   SECRET: ""
 
 
-#企业微信消息推送配�?
+#企业微信消息推送配置
 #https://open.work.weixin.qq.com/help2/pc/14931
 WXWORK:
   WEBHOOK_URL: ""
@@ -107,7 +106,7 @@ WEBHOOK:
 GITHUB:
   TOKEN: ""
 
-#代理配置项，�?http://127.0.0.1:8080", 端口扫描不会走代�?
+#代理配置项，"http://127.0.0.1:8080", 端口扫描不会走代理
 PROXY:
   HTTP_URL: ""
 
@@ -122,7 +121,7 @@ ARL:
     - 100.64.0.0/10
     #- 10.0.0.0/8
     #- 192.168.0.0/16
-  ## 禁止域名，不可为空数�?
+  ## 禁止域名，不可为空数组
   FORBIDDEN_DOMAINS:
     - xxx.xx
   #端口对应前端测试选项
@@ -132,7 +131,7 @@ ARL:
   #文件泄漏字典
   FILE_LEAK_DICT: "/code/app/dicts/file_top_2000.txt"
 
-  #域名爆破并发?
+  #域名爆破并发数
   DOMAIN_BRUTE_CONCURRENT: 300
   #组合生成的域名爆破并发数
   ALT_DNS_CONCURRENT: 1500

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -3,7 +3,7 @@ CELERY:
 
 
 MONGO:
-  URI : 'mongodb://admin:admin@127.0.0.1:27018/'
+  URI : 'mongodb://admin:admin@127.0.0.1:27018/?authSource=admin'
   DB : 'arl'
 
 #GeoIP 数据库文件配置项
@@ -12,7 +12,7 @@ GEOIP:
   ASN: '/code/backend/GeoLite2/GeoLite2-ASN.mmdb'
 
 
-#Fofa API 配置�?
+#Fofa API 配置项
 FOFA:
   URL: "https://fofa.info"
   EMAIL: "已经不需要配置了"
@@ -33,8 +33,7 @@ QUERY_PLUGIN:
     enable: true
   crtsh:
     enable: true
-  fofa:  # fofa 的key配置在上�?
-  fofa:  # fofa 的key配置在上?
+  fofa:  # fofa 的key配置在上面
     enable: true
   hunter_qax: # 网站 https://hunter.qianxin.com/
     api_key: ""
@@ -62,18 +61,18 @@ QUERY_PLUGIN:
     enable: false
 
 
-#*** 监控任务消息推送配�?****
-#监控任务消息推送配置，支持钉钉，飞书，企业微信，邮�?
-#如果不需要推送，可以将所有配置项都留�?
+#*** 监控任务消息推送配置 ****
+#监控任务消息推送配置，支持钉钉，飞书，企业微信，邮件
+#如果不需要推送，可以将所有配置项都留空
 #文档：https://tophanttechnology.github.io/ARL-doc/config_option/?h=%E6%B6%88%E6%81%AF#_1
-#钉钉消息推送配�?
-#钉钉添加机器人，请查�?
+#钉钉消息推送配置
+#钉钉添加机器人，请查看
 #https://github.com/TophantTechnology/ARL/wiki/ARL%202.3%20%E6%96%B0%E6%B7%BB%E5%8A%A0%E5%8A%9F%E8%83%BD%E8%AF%B4%E6%98%8E
 DINGDING:
   SECRET: ""
   ACCESS_TOKEN: ""
 
-#邮件推送配�?
+#邮件推送配置
 EMAIL:
   HOST: ""
   PORT: ""
@@ -81,14 +80,14 @@ EMAIL:
   PASSWORD: ""
   TO: ""
 
-#飞书消息推送配�? 需要设置签名校�?
+#飞书消息推送配置 需要设置签名校验
 #https://open.feishu.cn/document/client-docs/bot-v3/add-custom-bot
 FEISHU:
   WEBHOOK_URL: ""
   SECRET: ""
 
 
-#企业微信消息推送配�?
+#企业微信消息推送配置
 #https://open.work.weixin.qq.com/help2/pc/14931
 WXWORK:
   WEBHOOK_URL: ""
@@ -107,7 +106,7 @@ WEBHOOK:
 GITHUB:
   TOKEN: ""
 
-#代理配置项，�?http://127.0.0.1:8080", 端口扫描不会走代�?
+#代理配置项，"http://127.0.0.1:8080", 端口扫描不会走代理
 PROXY:
   HTTP_URL: ""
 
@@ -122,7 +121,7 @@ ARL:
     - 100.64.0.0/10
     #- 10.0.0.0/8
     #- 192.168.0.0/16
-  ## 禁止域名，不可为空数�?
+  ## 禁止域名，不可为空数组
   FORBIDDEN_DOMAINS:
     - xxx.xx
   #端口对应前端测试选项
@@ -132,7 +131,7 @@ ARL:
   #文件泄漏字典
   FILE_LEAK_DICT: "/code/backend/app/dicts/file_top_2000.txt"
 
-  #域名爆破并发?
+  #域名爆破并发数
   DOMAIN_BRUTE_CONCURRENT: 300
   #组合生成的域名爆破并发数
   ALT_DNS_CONCURRENT: 1500

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -15,6 +15,8 @@ cd frontend
 if ! command -v pnpm &> /dev/null; then
     echo "⚠️ 提示：本地未检测到 pnpm 包管理器，尝试通过 npm 自动安装..."
     npm install -g pnpm || sudo npm install -g pnpm
+    # 确保 npm 全局 bin 目录在 PATH 中
+    export PATH="$(npm config get prefix)/bin:$PATH"
 fi
 
 echo "📥 正在安装前端 node_modules 依赖包 (首次运行较慢)..."


### PR DESCRIPTION
具体变更
1. MongoDB 连接修复
- 文件: backend/config.yaml, backend/config-docker.example.yaml
- 内容: MongoDB URI 末尾增加 ?authSource=admin 参数，确保认证时在 admin 数据库进行身份校验，避免部分 MongoDB 版本认证失败。
2. Chromium 版本锁定移除
- 文件: Dockerfile.dev
- 内容: 移除 Chromium 固定版本号 147.0.7727.137-1~deb12u1，改回使用源的最新版本，避免特定版本从镜像源下架后导致构建失败。
3. 中文注释乱码修复
- 文件: backend/config.yaml, backend/config-docker.example.yaml
- 内容: 修复多处因编码问题导致的中文注释末尾乱码字符（如 配置�? → 配置项、邮�? → 邮件 等）。
4. pnpm PATH 修复
- 文件: start-dev.sh
- 内容: 在 npm install -g pnpm 之后增加 export PATH="$(npm config get prefix)/bin:$PATH"，确保 npm 全局 bin 目录在 PATH 中，避免安装完 pnpm 后无法立即调用。